### PR TITLE
bevy 0.17: fix incorrectly added event

### DIFF
--- a/rust/bevy_ios_notifications/src/plugin.rs
+++ b/rust/bevy_ios_notifications/src/plugin.rs
@@ -58,11 +58,6 @@ impl Plugin for IosNotificationsPlugin {
     fn build(&self, app: &mut App) {
         app.init_non_send_resource::<IosNotificationsResource>();
 
-        #[cfg(not(target_os = "ios"))]
-        {
-            app.add_event::<IosNotificationEvents>();
-        }
-
         #[cfg(target_os = "ios")]
         {
             crate::native::init();


### PR DESCRIPTION
send_event is only used in native code ; and currently that code leads to a:

```
error[E0277]: `IosNotificationEvents` is not an `Message`
   --> /home/tb/Documents/tech/rust/bevy_ios_notifications/rust/bevy_ios_notifications/src/plugin.rs:63:29
    |
 63 |             app.add_event::<IosNotificationEvents>();
    |                 ---------   ^^^^^^^^^^^^^^^^^^^^^ invalid `Message`
```